### PR TITLE
mercury: Update to version 115.3.0, fixed `checkver`

### DIFF
--- a/bucket/mercury.json
+++ b/bucket/mercury.json
@@ -1,12 +1,12 @@
 {
-    "version": "115.2.0",
+    "version": "115.3.0",
     "description": "Firefox fork with compiler optimizations and patches from Librewolf, Waterfox, and GNU IceCat.",
     "homepage": "https://thorium.rocks/mercury",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Alex313031/Mercury/releases/download/v.115.2.0/mercury-115.2.0.en-US.win64.zip",
-            "hash": "f41acde3933f5f3a612ca00a95853afba464ef81072b84a9d0ddf00a2ed3fd7c"
+            "url": "https://github.com/Alex313031/Mercury/releases/download/v.115.3.0/mercury_115.3.0_win64.zip",
+            "hash": "12687b036b2a80d3056aa0b5a469c3a34f500fb29b3f5974c00a100d662a5530"
         }
     },
     "extract_dir": "mercury-115.2.0.en-US.win64\\mercury",
@@ -26,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Alex313031/Mercury/releases/download/v.$version/mercury-$version.en-US.win64.zip",
+                "url": "https://github.com/Alex313031/Mercury/releases/download/v.$version/mercury_$version_win64.zip",
                 "extract_dir": "mercury-$version.en-US.win64\\mercury"
             }
         }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).