### PR TITLE
twitch-hls-client: remove 32 bit builds

### DIFF
--- a/bucket/twitch-hls-client.json
+++ b/bucket/twitch-hls-client.json
@@ -7,10 +7,6 @@
         "64bit": {
             "url": "https://github.com/2bc4/twitch-hls-client/releases/download/1.3.1/twitch-hls-client-x86_64-pc-windows-msvc.zip",
             "hash": "678573c9ea95e12ef7511c0cafadac666c0a12be8e37adcaf4de7b0d6cd80b01"
-        },
-        "32bit": {
-            "url": "https://github.com/2bc4/twitch-hls-client/releases/download/1.3.1/twitch-hls-client-i686-pc-windows-msvc.zip",
-            "hash": "6baccb768a229b19c2375d9af42c8bb19b6a40f75d4fc991d0253eaf650478f2"
         }
     },
     "pre_install": [
@@ -30,9 +26,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/2bc4/twitch-hls-client/releases/download/$version/twitch-hls-client-x86_64-pc-windows-msvc.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/2bc4/twitch-hls-client/releases/download/$version/twitch-hls-client-i686-pc-windows-msvc.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
I noticed my project is in here, I recently removed 32 bit builds because they fail to build due to a dependency update. I don't really know how scoop works but I hope this does it.