### PR TITLE
occt: Update to version 15.0.5

### DIFF
--- a/bucket/occt.json
+++ b/bucket/occt.json
@@ -1,5 +1,5 @@
 {
-    "version": "13.1.14",
+    "version": "15.0.5",
     "description": "OCCT is a comprehensive stability testing software suite.",
     "homepage": "https://www.ocbase.com/occt/personal",
     "license": {
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://dl.ocbase.com/per/stable/OCCT.exe",
-            "hash": "2c5551f6fff5ddf63c8f6a1daac095fbcf100b665fc0576876da101c93c24287"
+            "hash": "ed00b2bccc36335c23c482f380d6858ea04f67ab5628ea3fc69e23ee329d417c"
         }
     },
     "pre_install": "$null = if (!(Test-Path \"$persist_dir$($cfg = '/OCCT.config.json')\")) { Set-Content \"$dir$cfg\" '{\"CheckForUpdates\":\"Disabled\",\"EnableSound\":false,\"AllowOcbaseUpload\":false}' -NoNewline }",
@@ -25,7 +25,7 @@
             "try {",
             "    $null = (Invoke-WebRequest $url).Content -cmatch '/_next/static/([^/]+)/_buildManifest\\.js'",
             "    $Matches[1],",
-            "    (Invoke-RestMethod \"https://www.ocbase.com/_next/data/$($Matches[1])/download.json\").pageProps.occtReleases[0].stable.release.version.versionStr -join ' '",
+            "    (Invoke-RestMethod \"https://www.ocbase.com/_next/data/$($Matches[1])/download.json\").pageProps.occtReleasesWindows[0].stable.release.version.versionStr -join ' '",
             "}",
             "catch { '' }"
         ],
@@ -37,7 +37,7 @@
                 "url": "https://dl.ocbase.com/per/stable/OCCT.exe",
                 "hash": {
                     "url": "https://www.ocbase.com/_next/data/$matchBuildid/download.json",
-                    "jsonpath": "$.pageProps.occtReleases[0].stable.release.checksum"
+                    "jsonpath": "$.pageProps.occtReleasesWindows[0].stable.release.checksum"
                 }
             }
         }


### PR DESCRIPTION
fixes `checkver.script` & `autoupdate.hash`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
